### PR TITLE
Check for allowed work package context menu action

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,12 @@ GIT
       rubyzip
 
 PATH
+  remote: ../openproject-proto_plugin
+  specs:
+    openproject-proto_plugin (7.1.0)
+      rails (~> 6.0)
+
+PATH
   remote: modules/auth_plugins
   specs:
     openproject-auth_plugins (1.0.0)
@@ -1058,6 +1064,7 @@ DEPENDENCIES
   openproject-meeting!
   openproject-openid_connect!
   openproject-pdf_export!
+  openproject-proto_plugin!
   openproject-recaptcha!
   openproject-reporting!
   openproject-token (~> 2.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,12 +36,6 @@ GIT
       rubyzip
 
 PATH
-  remote: ../openproject-proto_plugin
-  specs:
-    openproject-proto_plugin (7.1.0)
-      rails (~> 6.0)
-
-PATH
   remote: modules/auth_plugins
   specs:
     openproject-auth_plugins (1.0.0)
@@ -1064,7 +1058,6 @@ DEPENDENCIES
   openproject-meeting!
   openproject-openid_connect!
   openproject-pdf_export!
-  openproject-proto_plugin!
   openproject-recaptcha!
   openproject-reporting!
   openproject-token (~> 2.2.0)

--- a/frontend/src/app/features/plugins/plugin-context.ts
+++ b/frontend/src/app/features/plugins/plugin-context.ts
@@ -32,6 +32,7 @@ import { DomAutoscrollService } from 'core-app/shared/helpers/drag-and-drop/dom-
  */
 export class OpenProjectPluginContext {
   private _knownHookNames = [
+    'workPackageBulkContextMenu',
     'workPackageTableContextMenu',
     'workPackageSingleContextMenu',
     'workPackageNewInitialization',

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -103,7 +103,6 @@ export class WorkPackageContextMenuHelperService {
 
   public getIntersectOfPermittedActions(workPackages:any) {
     const bulkPermittedActions:any = [];
-
     const possibleActions = this.BULK_ACTIONS.concat(this.HookService.call('workPackageBulkContextMenu'));
     const permittedActions = _.filter(possibleActions, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.isActionAllowed(workPackage, action)));
 
@@ -111,8 +110,6 @@ export class WorkPackageContextMenuHelperService {
       bulkPermittedActions.push({
         key: permittedAction.key,
         text: permittedAction.text,
-        // the icon field is necessary for custom plugins
-        icon: permittedAction.icon,
         link: this.getBulkActionLink(permittedAction, workPackages),
       });
     });

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -111,6 +111,7 @@ export class WorkPackageContextMenuHelperService {
       bulkPermittedActions.push({
         key: permittedAction.key,
         text: permittedAction.text,
+        // the optional icon field is necessary for custom plugins
         icon!: permittedAction.icon,
         link: this.getBulkActionLink(permittedAction, workPackages),
       });

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -111,6 +111,7 @@ export class WorkPackageContextMenuHelperService {
       bulkPermittedActions.push({
         key: permittedAction.key,
         text: permittedAction.text,
+        icon!: permittedAction.icon,
         link: this.getBulkActionLink(permittedAction, workPackages),
       });
     });

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -111,8 +111,8 @@ export class WorkPackageContextMenuHelperService {
       bulkPermittedActions.push({
         key: permittedAction.key,
         text: permittedAction.text,
-        // the optional icon field is necessary for custom plugins
-        icon!: permittedAction.icon,
+        // the icon field is necessary for custom plugins
+        icon: permittedAction.icon,
         link: this.getBulkActionLink(permittedAction, workPackages),
       });
     });

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -103,6 +103,7 @@ export class WorkPackageContextMenuHelperService {
 
   public getIntersectOfPermittedActions(workPackages:any) {
     const bulkPermittedActions:any = [];
+
     const possibleActions = this.BULK_ACTIONS.concat(this.HookService.call('workPackageBulkContextMenu'));
     const permittedActions = _.filter(possibleActions, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.isActionAllowed(workPackage, action)));
 

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -103,8 +103,8 @@ export class WorkPackageContextMenuHelperService {
 
   public getIntersectOfPermittedActions(workPackages:any) {
     const bulkPermittedActions:any = [];
-
-    const permittedActions = _.filter(this.BULK_ACTIONS, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.getAllowedActions(workPackage, [action]).length >= 1));
+    const possibleActions = this.BULK_ACTIONS.concat(this.HookService.call('workPackageBulkContextMenu'));
+    const permittedActions = _.filter(possibleActions, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.getAllowedActions(workPackage, [action]).length >= 1));
 
     _.each(permittedActions, (permittedAction:any) => {
       bulkPermittedActions.push({

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -105,7 +105,7 @@ export class WorkPackageContextMenuHelperService {
     const bulkPermittedActions:any = [];
 
     const possibleActions = this.BULK_ACTIONS.concat(this.HookService.call('workPackageBulkContextMenu'));
-    const permittedActions = _.filter(possibleActions, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.isActionAllowed(workPackage, action)));
+    const permittedActions = _.filter(this.BULK_ACTIONS, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.isActionAllowed(workPackage, action)));
 
     _.each(permittedActions, (permittedAction:any) => {
       bulkPermittedActions.push({

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -104,7 +104,7 @@ export class WorkPackageContextMenuHelperService {
   public getIntersectOfPermittedActions(workPackages:any) {
     const bulkPermittedActions:any = [];
     const possibleActions = this.BULK_ACTIONS.concat(this.HookService.call('workPackageBulkContextMenu'));
-    const permittedActions = _.filter(possibleActions, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.getAllowedActions(workPackage, [action]).length >= 1));
+    const permittedActions = _.filter(possibleActions, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.isActionAllowed(workPackage, action)));
 
     _.each(permittedActions, (permittedAction:any) => {
       bulkPermittedActions.push({
@@ -128,6 +128,10 @@ export class WorkPackageContextMenuHelperService {
     const queryParts = linkAndQueryString.concat(new Array(serializedIdParams));
 
     return `${link}?${queryParts.join('&')}`;
+  }
+
+  private isActionAllowed(workPackage:WorkPackageResource, action:WorkPackageAction):boolean {
+    return _.filter(this.getAllowedActions(workPackage, [action]), (a) => a === action).length >= 1;
   }
 
   private getAllowedActions(workPackage:WorkPackageResource, actions:WorkPackageAction[]):WorkPackageAction[] {

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -105,7 +105,7 @@ export class WorkPackageContextMenuHelperService {
     const bulkPermittedActions:any = [];
 
     const possibleActions = this.BULK_ACTIONS.concat(this.HookService.call('workPackageBulkContextMenu'));
-    const permittedActions = _.filter(this.BULK_ACTIONS, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.isActionAllowed(workPackage, action)));
+    const permittedActions = _.filter(possibleActions, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.isActionAllowed(workPackage, action)));
 
     _.each(permittedActions, (permittedAction:any) => {
       bulkPermittedActions.push({


### PR DESCRIPTION
At the moment this PR is adding a `isAllowedActions` helper and filtering `possible actions` into `permitted actions` 